### PR TITLE
Fixes Null usernames when they don't meet requirements.

### DIFF
--- a/src/pages/[slug].tsx
+++ b/src/pages/[slug].tsx
@@ -30,26 +30,24 @@ const ProfilePage: NextPage<{ username: string }> = ({ username }) => {
     username,
   });
   if (!data) return <div>404</div>;
-
   return (
     <>
       <Head>
-        <title>{data.username}</title>
+        <title>{data.username ?? data.externalUsername}</title>
       </Head>
       <PageLayout>
         <div className="relative h-36 bg-slate-600">
           <Image
             src={data.profileImageUrl}
-            alt={`${data.username ?? ""}'s profile pic`}
+            alt={`${data.username ?? data.externalUsername}'s profile pic`}
             width={128}
             height={128}
             className="absolute bottom-0 left-0 -mb-[64px] ml-4 rounded-full border-4 border-black bg-black"
           />
         </div>
         <div className="h-[64px]"></div>
-        <div className="p-4 text-2xl font-bold">{`@${
-          data.username ?? ""
-        }`}</div>
+        <div className="p-4 text-2xl font-bold">{`@${data.username ?? data.externalUsername
+          }`}</div>
         <div className="w-full border-b border-slate-400" />
         <ProfileFeed userId={data.id} />
       </PageLayout>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,11 +32,10 @@ const CreatePostWizard = () => {
     },
   });
 
-  console.log(user);
-
   if (!user) return null;
 
   return (
+
     <div className="flex w-full gap-3">
       <Image
         src={user.profileImageUrl}

--- a/src/server/api/routers/posts.ts
+++ b/src/server/api/routers/posts.ts
@@ -23,6 +23,7 @@ const addUserDataToPosts = async (posts: Post[]) => {
   ).map(filterUserForClient);
 
   return posts.map((post) => {
+
     const author = users.find((user) => user.id === post.authorId);
 
     if (!author) {
@@ -32,7 +33,16 @@ const addUserDataToPosts = async (posts: Post[]) => {
         message: `Author for post not found. POST ID: ${post.id}, USER ID: ${post.authorId}`,
       });
     }
-
+    if (!author.username) {
+      // user the ExternalUsername
+      if (!author.externalUsername) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Author has no GitHub Account: ${author.id}`,
+        });
+      }
+      author.username = author.externalUsername;
+    }
     return {
       post,
       author: {

--- a/src/server/api/routers/profile.ts
+++ b/src/server/api/routers/profile.ts
@@ -1,3 +1,4 @@
+
 import { clerkClient } from "@clerk/nextjs/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
@@ -14,12 +15,23 @@ export const profileRouter = createTRPCRouter({
       });
 
       if (!user) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "User not found",
-        });
+        // if we hit here we need a unsantized username so hit api once more and find the user.
+        const users = (
+          await clerkClient.users.getUserList({
+            limit: 200,
+          })
+        )
+        const user = users.find((user) => user.externalAccounts.find((account) => account.username === input.username));
+        if (!user) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "User not found",
+          });
+        }
+        return filterUserForClient(user)
       }
 
       return filterUserForClient(user);
+
     }),
 });

--- a/src/server/helpers/filterUserForClient.ts
+++ b/src/server/helpers/filterUserForClient.ts
@@ -4,5 +4,6 @@ export const filterUserForClient = (user: User) => {
     id: user.id,
     username: user.username,
     profileImageUrl: user.profileImageUrl,
+    externalUsername: user.externalAccounts[0]?.username
   };
 };

--- a/src/server/helpers/filterUserForClient.ts
+++ b/src/server/helpers/filterUserForClient.ts
@@ -4,6 +4,6 @@ export const filterUserForClient = (user: User) => {
     id: user.id,
     username: user.username,
     profileImageUrl: user.profileImageUrl,
-    externalUsername: user.externalAccounts[0]?.username
+    externalUsername: user.externalAccounts.find((externalAccount) => externalAccount.provider === "oauth_github")?.username || null
   };
 };


### PR DESCRIPTION
This adds the ability to handle null usernames when they don't comply with Clerk's username requirements and you don't want to let the user type their own.

- Length 4-64
- One Alpha Char

Feel free to make modifications as needed. 

We use `user.externalAccounts.find((externalAccount) => externalAccount.provider === "oauth_github")?.username || null` so this could be modified if someone is using any OAuth account. 

This is until we work on username requirements being set by the user versus Clerk. When Clerk updates that feature we can remove this change.