### PR TITLE
Fix env name used GitHub CI output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         run: npm run lint
 
       - name: Print Environment Variable
-        run: echo $MY_ENV_VAR
+        run: echo $DATABASE_URL


### PR DESCRIPTION
**Minor**
In the `Print Environment Variable` step it is printing the original, now unset environment variable `$MY_ENV_VAR`.  Switched to print `$DATABASE_URL` instead, though removing the step entirely is an alternative.