### PR TITLE
Replace deprecated createProxySSGHelpers

### DIFF
--- a/src/server/helpers/ssgHelper.ts
+++ b/src/server/helpers/ssgHelper.ts
@@ -1,10 +1,10 @@
-import { createProxySSGHelpers } from "@trpc/react-query/ssg";
+import { createServerSideHelpers } from "@trpc/react-query/server";
 import { appRouter } from "~/server/api/root";
 import { prisma } from "~/server/db";
 import superjson from "superjson";
 
 export const generateSSGHelper = () =>
-  createProxySSGHelpers({
+  createServerSideHelpers({
     router: appRouter,
     ctx: { prisma, userId: null },
     transformer: superjson, // optional - adds superjson serialization


### PR DESCRIPTION
'createProxySSGHelpers' is deprecated.ts(6385)

index.d.ts(11, 4): The declaration was marked as deprecated here.